### PR TITLE
Use S3 native CRC64NVME full-object checksums (v8.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Full documentation available on [Read the Docs](https://awsimple.readthedocs.io/
 - Convert back and forth between DynamoDB items and Python dictionaries automatically. Converts many common data types to DynamoDB compatible types,
 including nested structures, sets, images (PIL), and Enum/StrEnum.
 
-- True file hashing (SHA512) for S3 files (S3's etag is not a true file hash).
+- Full-object checksums (CRC64NVME) for S3 files (S3's etag is not a true file hash).
 
 - Supports moto mock and localstack. Handy for testing and CI.
 
@@ -106,12 +106,14 @@ level API to AWS services (such as S3, DynamoDB, SNS, and SQS) to improve progra
 
 ## S3
 
-`awsimple` uses SHA-512 hashes to test for file equivalency (e.g. to avoid re-uploading unchanged files).
-Uploads use S3's native SHA-512 checksum (server-validated on upload and returned on `head_object`).
-Objects written by older awsimple versions (which stored the hash in custom object metadata) are detected
-and always re-uploaded, so every object awsimple writes ends up with the native checksum. Objects without
-any full-object hash (e.g. multipart uploads, whose native checksum is composite, or objects written by
-other tools) fall back to modification-time and file-size comparison.
+`awsimple` uses S3's native full-object checksums to test for file equivalency (e.g. to avoid re-uploading
+unchanged files). Uploads use CRC64NVME - the algorithm S3 itself defaults to, and the only one S3 computes
+as a full-object value for both single-part and multipart uploads - and S3 validates the data against the
+checksum server-side before storing. Objects written by other tools with a native full-object SHA-512
+checksum are also recognized and compared. Objects written by older awsimple versions (which stored a
+SHA-512 in custom object metadata) are detected and always re-uploaded, so every object awsimple writes
+ends up with the native checksum. Objects without any recognizable full-object hash fall back to
+modification-time and file-size comparison.
 
 ## Caching
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,12 @@ level API to AWS services (such as S3, DynamoDB, SNS, and SQS) to improve progra
 
 ## S3
 
-`awsimple` calculates the local file hash (sha512) and inserts it into the S3 object metadata.  This is used
-to test for file equivalency.
+`awsimple` uses SHA-512 hashes to test for file equivalency (e.g. to avoid re-uploading unchanged files).
+Uploads use S3's native SHA-512 checksum (server-validated on upload and returned on `head_object`).
+Objects written by older awsimple versions (which stored the hash in custom object metadata) are detected
+and always re-uploaded, so every object awsimple writes ends up with the native checksum. Objects without
+any full-object hash (e.g. multipart uploads, whose native checksum is composite, or objects written by
+other tools) fall back to modification-time and file-size comparison.
 
 ## Caching
 

--- a/awsimple/__init__.py
+++ b/awsimple/__init__.py
@@ -6,7 +6,7 @@ from .cache import get_disk_free, get_directory_size, lru_cache_write, CacheAcce
 from .dynamodb import DynamoDBAccess, dict_to_dynamodb, DBItemNotFound, DynamoDBTableNotFound, dynamodb_to_json, dynamodb_to_dict, QuerySelection, DictKey, convert_serializable_special_cases
 from .dynamodb import KeyType, aws_name_to_key_type
 from .dynamodb_miv import DynamoDBMIVUI, miv_string, get_time_us, miv_us_to_timestamp
-from .s3 import S3Access, S3DownloadStatus, S3ObjectMetadata, BucketNotFound
+from .s3 import S3Access, S3DownloadStatus, S3ObjectMetadata, BucketNotFound, get_bytes_crc64nvme, get_file_crc64nvme
 from .sqs import SQSAccess, SQSPollAccess, aws_sqs_long_poll_max_wait_time, aws_sqs_max_messages, get_all_sqs_queues
 from .sns import SNSAccess
 from .pubsub import Pub, Sub

--- a/awsimple/__init__.py
+++ b/awsimple/__init__.py
@@ -6,7 +6,7 @@ from .cache import get_disk_free, get_directory_size, lru_cache_write, CacheAcce
 from .dynamodb import DynamoDBAccess, dict_to_dynamodb, DBItemNotFound, DynamoDBTableNotFound, dynamodb_to_json, dynamodb_to_dict, QuerySelection, DictKey, convert_serializable_special_cases
 from .dynamodb import KeyType, aws_name_to_key_type
 from .dynamodb_miv import DynamoDBMIVUI, miv_string, get_time_us, miv_us_to_timestamp
-from .s3 import S3Access, S3DownloadStatus, S3ObjectMetadata, BucketNotFound, get_bytes_crc64nvme, get_file_crc64nvme
+from .s3 import S3Access, S3DownloadStatus, S3ObjectMetadata, BucketNotFound
 from .sqs import SQSAccess, SQSPollAccess, aws_sqs_long_poll_max_wait_time, aws_sqs_max_messages, get_all_sqs_queues
 from .sns import SNSAccess
 from .pubsub import Pub, Sub

--- a/awsimple/__version__.py
+++ b/awsimple/__version__.py
@@ -1,7 +1,7 @@
 __application_name__ = "awsimple"
 __title__ = __application_name__
 __author__ = "abel"
-__version__ = "7.3.0"
+__version__ = "8.0.0"
 __author_email__ = "j@abel.co"
 __url__ = "https://github.com/jamesabel/awsimple"
 __download_url__ = "https://github.com/jamesabel/awsimple"

--- a/awsimple/s3.py
+++ b/awsimple/s3.py
@@ -20,7 +20,7 @@ from boto3.s3.transfer import TransferConfig
 from s3transfer import S3UploadFailedError
 import urllib3.exceptions
 from typeguard import typechecked
-from hashy import get_file_sha512, get_bytes_sha512, get_dls_sha512
+from hashy import get_file_sha512, get_bytes_sha512, get_dls_sha512, get_file_crc64nvme, get_bytes_crc64nvme
 from yasf import sf
 
 from awsimple import (
@@ -117,36 +117,6 @@ def _native_checksum_to_hex(checksum_base64: Union[str, None]) -> Union[str, Non
     if checksum_base64 is None or "-" in checksum_base64:
         return None
     return base64.b64decode(checksum_base64).hex()
-
-
-@typechecked()
-def get_bytes_crc64nvme(data: bytes) -> str:
-    """
-    Compute the CRC64NVME checksum of bytes as a hex string (comparable with S3's native full-object CRC64NVME checksum).
-
-    :param data: input bytes
-    :return: CRC64NVME as a hex string
-    """
-    from awscrt import checksums as awscrt_checksums  # awscrt comes in via boto3[crt] (also required by botocore to compute CRC64NVME checksums on upload)
-
-    return awscrt_checksums.crc64nvme(data, 0).to_bytes(8, "big").hex()
-
-
-@typechecked()
-def get_file_crc64nvme(file_path: Union[str, Path]) -> str:
-    """
-    Compute the CRC64NVME checksum of a file as a hex string (comparable with S3's native full-object CRC64NVME checksum).
-
-    :param file_path: path to the file
-    :return: CRC64NVME as a hex string
-    """
-    from awscrt import checksums as awscrt_checksums  # awscrt comes in via boto3[crt] (also required by botocore to compute CRC64NVME checksums on upload)
-
-    crc = 0
-    with open(file_path, "rb") as f:
-        while chunk := f.read(1 << 20):
-            crc = awscrt_checksums.crc64nvme(chunk, crc)
-    return crc.to_bytes(8, "big").hex()
 
 
 def _get_json_key(s3_key: str):

--- a/awsimple/s3.py
+++ b/awsimple/s3.py
@@ -39,9 +39,11 @@ from awsimple import (
 # detect objects written by older awsimple versions, which are always re-uploaded so that every object gains the native checksum.
 sha512_string = f"{__application_name__}-sha512"
 
-# S3's maximum single-part object size. Uploads are kept single-part up to this size so the native SHA-512 checksum is a
-# full-object checksum - multipart uploads get a composite checksum-of-part-checksums, which can't be compared to a local file hash.
-max_single_part_size = 5 * 1024**3  # 5 GiB
+# Uploads at or above this size use multipart (the boto3 default threshold). awsimple uses CRC64NVME checksums everywhere since
+# it's the only checksum family S3 computes as a full-object value for both single-part and multipart uploads (SHA-family multipart
+# checksums are composite and can't be compared to a local file hash), and it's also S3's own default - so objects written by other
+# modern tools are usually comparable too.
+default_multipart_threshold = 8 * 1024 * 1024  # 8 MiB
 
 json_extension = ".json"
 
@@ -77,20 +79,23 @@ class S3ObjectMetadata:
     sha512: Union[str, None]  # hex string - S3's native full-object SHA-512 checksum (None if the object doesn't have one, e.g. multipart uploads or objects written by other tools)
     url: str  # URL of S3 object
     legacy_sha512: Union[str, None] = None  # hex string from awsimple's legacy custom metadata - only present on objects written by awsimple versions before native checksum support
+    crc64nvme: Union[str, None] = None  # hex string - S3's native full-object CRC64NVME checksum (awsimple uses this for multipart uploads)
 
     def get_sha512(self) -> str:
         """
-        Get hash used to compare S3 objects. If the native SHA512 is available (recommended), then use that. If not (e.g. an S3 object wasn't written with AWSimple), create a "substitute"
-        SHA512 hash that should change if the object contents change.
-        :return: SHA512 hash (as string)
+        Get a content-derived value used to compare and cache S3 objects. If the native SHA512 is available (recommended), then use that. Otherwise use the native full-object
+        CRC64NVME (e.g. multipart uploads). If neither is available (e.g. an S3 object wasn't written with AWSimple), create a "substitute" hash that should change if the object
+        contents change.
+        :return: hash (as string)
         """
         if (sha512_value := self.sha512) is None:
-            # round timestamp to seconds to try to avoid possible small deltas when dealing with time and floats
-            mtime_as_int = int(round(self.mtime.timestamp()))
-            metadata_list = [self.bucket, self.key, self.size, mtime_as_int]
-            if self.etag is not None and len(self.etag) > 0:
-                metadata_list.append(self.etag)
-            sha512_value = get_dls_sha512(metadata_list)
+            if (sha512_value := self.crc64nvme) is None:
+                # round timestamp to seconds to try to avoid possible small deltas when dealing with time and floats
+                mtime_as_int = int(round(self.mtime.timestamp()))
+                metadata_list = [self.bucket, self.key, self.size, mtime_as_int]
+                if self.etag is not None and len(self.etag) > 0:
+                    metadata_list.append(self.etag)
+                sha512_value = get_dls_sha512(metadata_list)
 
         return sha512_value
 
@@ -112,6 +117,36 @@ def _native_checksum_to_hex(checksum_base64: Union[str, None]) -> Union[str, Non
     if checksum_base64 is None or "-" in checksum_base64:
         return None
     return base64.b64decode(checksum_base64).hex()
+
+
+@typechecked()
+def get_bytes_crc64nvme(data: bytes) -> str:
+    """
+    Compute the CRC64NVME checksum of bytes as a hex string (comparable with S3's native full-object CRC64NVME checksum).
+
+    :param data: input bytes
+    :return: CRC64NVME as a hex string
+    """
+    from awscrt import checksums as awscrt_checksums  # awscrt comes in via boto3[crt] (also required by botocore to compute CRC64NVME checksums on upload)
+
+    return awscrt_checksums.crc64nvme(data, 0).to_bytes(8, "big").hex()
+
+
+@typechecked()
+def get_file_crc64nvme(file_path: Union[str, Path]) -> str:
+    """
+    Compute the CRC64NVME checksum of a file as a hex string (comparable with S3's native full-object CRC64NVME checksum).
+
+    :param file_path: path to the file
+    :return: CRC64NVME as a hex string
+    """
+    from awscrt import checksums as awscrt_checksums  # awscrt comes in via boto3[crt] (also required by botocore to compute CRC64NVME checksums on upload)
+
+    crc = 0
+    with open(file_path, "rb") as f:
+        while chunk := f.read(1 << 20):
+            crc = awscrt_checksums.crc64nvme(chunk, crc)
+    return crc.to_bytes(8, "big").hex()
 
 
 def _get_json_key(s3_key: str):
@@ -144,22 +179,21 @@ class S3Access(CacheAccess):
 
     def _upload_extra_args(self) -> Dict[str, Any]:
         """
-        ExtraArgs for uploads: the native SHA-512 checksum and an optional public-read ACL.
+        ExtraArgs for uploads: the native full-object CRC64NVME checksum and an optional public-read ACL.
 
         :return: ExtraArgs dict
         """
         # S3 validates the data against the (SDK computed) checksum before storing
-        extra_args: Dict[str, Any] = {"ChecksumAlgorithm": "SHA512"}
+        extra_args: Dict[str, Any] = {"ChecksumAlgorithm": "CRC64NVME"}
         if self.public_readable:
             extra_args["ACL"] = "public-read"
         return extra_args
 
     def get_s3_transfer_config(self) -> TransferConfig:
         # workaround threading issue https://github.com/boto/s3transfer/issues/197
-        # keep uploads single-part up to S3's 5 GiB single-part limit so the native SHA-512 checksum is full-object (see max_single_part_size);
-        # derived class can overload this if a different config is desired (e.g. multipart for very large files - those fall back to
-        # awsimple's custom metadata for change detection since their native checksum is composite)
-        s3_transfer_config = TransferConfig(use_threads=False, multipart_threshold=max_single_part_size)
+        # derived class can overload this if a different config is desired (the multipart threshold also determines which native
+        # checksum algorithm uploads use - see _upload_extra_args)
+        s3_transfer_config = TransferConfig(use_threads=False, multipart_threshold=default_multipart_threshold)
         return s3_transfer_config
 
     @typechecked()
@@ -209,7 +243,7 @@ class S3Access(CacheAccess):
         log.debug(f"writing {self.bucket_name}/{s3_key}")
         assert self.resource is not None
         # S3 validates the data against the (SDK computed) checksum before storing
-        self.resource.Object(self.bucket_name, s3_key).put(Body=input_str, ChecksumAlgorithm="SHA512")
+        self.resource.Object(self.bucket_name, s3_key).put(Body=input_str, ChecksumAlgorithm="CRC64NVME")
 
     @typechecked()
     def write_lines(self, input_lines: List[str], s3_key: str):
@@ -249,22 +283,24 @@ class S3Access(CacheAccess):
             file_path = Path(file_path)
 
         file_mtime = os.path.getmtime(file_path)
-        file_sha512 = get_file_sha512(file_path)
+        file_crc64nvme = get_file_crc64nvme(file_path)
         if force:
             upload_flag = True
         else:
             if self.object_exists(s3_key):
                 s3_object_metadata = self.get_s3_object_metadata(s3_key)
                 log.info(f"{s3_object_metadata=}")
-                if s3_object_metadata.sha512 is not None:
-                    # use the native full-object checksum, if the object has one (note that .get_sha512() never returns None - it synthesizes a substitute hash - so check .sha512 itself)
-                    upload_flag = file_sha512 != s3_object_metadata.sha512
+                if s3_object_metadata.crc64nvme is not None:
+                    # use the native full-object checksum, if the object has one (note that .get_sha512() never returns None - it synthesizes a substitute hash - so check the field itself)
+                    upload_flag = file_crc64nvme != s3_object_metadata.crc64nvme
+                elif s3_object_metadata.sha512 is not None:
+                    # the object was written by another tool with a native full-object SHA-512 checksum
+                    upload_flag = get_file_sha512(file_path) != s3_object_metadata.sha512
                 elif s3_object_metadata.legacy_sha512 is not None:
                     # the object was written by an older awsimple using the legacy metadata hash - always re-upload it so it gains the native checksum
                     upload_flag = True
                 else:
-                    # no hash is available (e.g. the object was written by another tool, or by a multipart upload whose native checksum is composite),
-                    # so compare modification time and file size
+                    # no hash is available, so compare modification time and file size (free and robust, but weaker than a hash)
                     sizes_equal = os.path.getsize(file_path) == s3_object_metadata.size
                     mtimes_equal = isclose(file_mtime, s3_object_metadata.mtime.timestamp(), abs_tol=self.mtime_abs_tol)
                     upload_flag = not (sizes_equal and mtimes_equal)
@@ -273,7 +309,7 @@ class S3Access(CacheAccess):
 
         uploaded_flag = False
         if upload_flag:
-            log.info(f"local file : {file_sha512=},force={force} - uploading")
+            log.info(f"local file : {file_crc64nvme=},force={force} - uploading")
 
             transfer_retry_count = 0
             extra_args = self._upload_extra_args()
@@ -296,7 +332,7 @@ class S3Access(CacheAccess):
                 raise AWSimpleException(f"couldn't upload {file_path} to {self.bucket_name}/{s3_key} after {self.retry_count} attempts")
 
         else:
-            log.info(f"file hash of {file_sha512} is the same as is already on S3 and force={force} - not uploading")
+            log.info(f"file checksum of {file_crc64nvme} is the same as is already on S3 and force={force} - not uploading")
 
         return uploaded_flag
 
@@ -313,19 +349,22 @@ class S3Access(CacheAccess):
 
         s3_key = _get_json_key(s3_key)
         json_as_bytes = serializable_object_to_json_as_bytes(json_serializable_object)
-        json_sha512 = get_bytes_sha512(json_as_bytes)
+        json_crc64nvme = get_bytes_crc64nvme(json_as_bytes)
         upload_flag = True
         if not force and self.object_exists(s3_key):
             s3_object_metadata = self.get_s3_object_metadata(s3_key)
             log.info(f"{s3_object_metadata=}")
-            if s3_object_metadata.sha512 is not None:
-                # use the native full-object checksum, if the object has one (note that .get_sha512() never returns None - it synthesizes a substitute hash - so check .sha512 itself)
-                upload_flag = json_sha512 != s3_object_metadata.sha512
+            if s3_object_metadata.crc64nvme is not None:
+                # use the native full-object checksum, if the object has one (note that .get_sha512() never returns None - it synthesizes a substitute hash - so check the field itself)
+                upload_flag = json_crc64nvme != s3_object_metadata.crc64nvme
+            elif s3_object_metadata.sha512 is not None:
+                # the object was written by another tool with a native full-object SHA-512 checksum
+                upload_flag = get_bytes_sha512(json_as_bytes) != s3_object_metadata.sha512
             # otherwise upload_flag stays True - objects written by older awsimple (legacy metadata hash) or without any hash are always re-uploaded so they gain the native checksum
 
         uploaded_flag = False
         if upload_flag:
-            log.info(f"{json_sha512=},force={force} - uploading")
+            log.info(f"{json_crc64nvme=},force={force} - uploading")
 
             transfer_retry_count = 0
             while not uploaded_flag and transfer_retry_count < self.retry_count:
@@ -333,7 +372,7 @@ class S3Access(CacheAccess):
                 try:
                     s3_object = self.resource.Object(self.bucket_name, s3_key)
                     # S3 validates the data against the (SDK computed) checksum before storing
-                    put_kwargs: Dict[str, Any] = {"Body": json_as_bytes, "ChecksumAlgorithm": "SHA512"}
+                    put_kwargs: Dict[str, Any] = {"Body": json_as_bytes, "ChecksumAlgorithm": "CRC64NVME"}
                     if self.public_readable:
                         put_kwargs["ACL"] = "public-read"
                     s3_object.put(**put_kwargs)
@@ -347,7 +386,7 @@ class S3Access(CacheAccess):
                 raise AWSimpleException(f"couldn't upload JSON to {self.bucket_name}/{s3_key} after {self.retry_count} attempts")
 
         else:
-            log.info(f"file hash of {json_sha512} is the same as is already on S3 and force={force} - not uploading")
+            log.info(f"checksum of {json_crc64nvme} is the same as is already on S3 and force={force} - not uploading")
 
         return uploaded_flag
 
@@ -515,8 +554,8 @@ class S3Access(CacheAccess):
                 raise AWSimpleException(f"{self.bucket_name=} {s3_key=} does not exist") from e
             raise
         assert isinstance(self.bucket_name, str)  # mainly for mypy
-        # sha512 is S3's native (server-validated) full-object SHA-512 checksum; legacy_sha512 is awsimple's legacy custom metadata,
-        # kept readable so objects written by older awsimple versions can be detected (and re-uploaded to gain the native checksum)
+        # sha512 and crc64nvme are S3's native (server-validated) full-object checksums; legacy_sha512 is awsimple's legacy custom
+        # metadata, kept readable so objects written by older awsimple versions can be detected (and re-uploaded to gain the native checksum)
         s3_object_metadata = S3ObjectMetadata(
             self.bucket_name,
             s3_key,
@@ -526,6 +565,7 @@ class S3Access(CacheAccess):
             _native_checksum_to_hex(head.get("ChecksumSHA512")),
             self.get_s3_object_url(s3_key),
             head.get("Metadata", {}).get(sha512_string),
+            _native_checksum_to_hex(head.get("ChecksumCRC64NVME")),
         )
         log.debug(f"{s3_object_metadata=}")
         return s3_object_metadata

--- a/awsimple/s3.py
+++ b/awsimple/s3.py
@@ -2,6 +2,7 @@
 S3 Access
 """
 
+import base64
 import os
 import shutil
 import time
@@ -9,7 +10,7 @@ from math import isclose
 from pathlib import Path
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 import json
 from logging import getLogger
 
@@ -19,7 +20,7 @@ from boto3.s3.transfer import TransferConfig
 from s3transfer import S3UploadFailedError
 import urllib3.exceptions
 from typeguard import typechecked
-from hashy import get_string_sha512, get_file_sha512, get_bytes_sha512, get_dls_sha512
+from hashy import get_file_sha512, get_bytes_sha512, get_dls_sha512
 from yasf import sf
 
 from awsimple import (
@@ -34,7 +35,13 @@ from awsimple import (
 )
 
 # Use this project's name as a prefix to avoid string collisions.  Use dashes instead of underscore since that's AWS's convention.
+# This custom metadata predates S3's native SHA-512 checksum support (April 2026). It is no longer written - it is only read to
+# detect objects written by older awsimple versions, which are always re-uploaded so that every object gains the native checksum.
 sha512_string = f"{__application_name__}-sha512"
+
+# S3's maximum single-part object size. Uploads are kept single-part up to this size so the native SHA-512 checksum is a
+# full-object checksum - multipart uploads get a composite checksum-of-part-checksums, which can't be compared to a local file hash.
+max_single_part_size = 5 * 1024**3  # 5 GiB
 
 json_extension = ".json"
 
@@ -67,12 +74,13 @@ class S3ObjectMetadata:
     size: int
     mtime: datetime
     etag: str  # generally not used
-    sha512: Union[str, None]  # hex string - only entries written with awsimple will have this
+    sha512: Union[str, None]  # hex string - S3's native full-object SHA-512 checksum (None if the object doesn't have one, e.g. multipart uploads or objects written by other tools)
     url: str  # URL of S3 object
+    legacy_sha512: Union[str, None] = None  # hex string from awsimple's legacy custom metadata - only present on objects written by awsimple versions before native checksum support
 
     def get_sha512(self) -> str:
         """
-        Get hash used to compare S3 objects. If the SHA512 is available (recommended), then use that. If not (e.g. an S3 object wasn't written with AWSimple), create a "substitute"
+        Get hash used to compare S3 objects. If the native SHA512 is available (recommended), then use that. If not (e.g. an S3 object wasn't written with AWSimple), create a "substitute"
         SHA512 hash that should change if the object contents change.
         :return: SHA512 hash (as string)
         """
@@ -90,6 +98,20 @@ class S3ObjectMetadata:
 @typechecked()
 def serializable_object_to_json_as_bytes(json_serializable_object: Union[List, Dict]) -> bytes:
     return bytes(json.dumps(json_serializable_object, default=convert_serializable_special_cases).encode("UTF-8"))
+
+
+@typechecked()
+def _native_checksum_to_hex(checksum_base64: Union[str, None]) -> Union[str, None]:
+    """
+    Convert an S3 native checksum (base64 encoded) to a hex string comparable with locally computed hashes.
+    Composite (multipart) checksums have a "-<part count>" suffix and do not represent the whole object, so they convert to None.
+
+    :param checksum_base64: base64 encoded checksum from S3 (or None)
+    :return: hex string, or None if no full-object checksum available
+    """
+    if checksum_base64 is None or "-" in checksum_base64:
+        return None
+    return base64.b64decode(checksum_base64).hex()
 
 
 def _get_json_key(s3_key: str):
@@ -120,10 +142,24 @@ class S3Access(CacheAccess):
         self._bucket_region = None  # type: Union[str, None]  # lazily determined and cached
         super().__init__(resource_name="s3", **kwargs)
 
+    def _upload_extra_args(self) -> Dict[str, Any]:
+        """
+        ExtraArgs for uploads: the native SHA-512 checksum and an optional public-read ACL.
+
+        :return: ExtraArgs dict
+        """
+        # S3 validates the data against the (SDK computed) checksum before storing
+        extra_args: Dict[str, Any] = {"ChecksumAlgorithm": "SHA512"}
+        if self.public_readable:
+            extra_args["ACL"] = "public-read"
+        return extra_args
+
     def get_s3_transfer_config(self) -> TransferConfig:
         # workaround threading issue https://github.com/boto/s3transfer/issues/197
-        # derived class can overload this if a different config is desired
-        s3_transfer_config = TransferConfig(use_threads=False)
+        # keep uploads single-part up to S3's 5 GiB single-part limit so the native SHA-512 checksum is full-object (see max_single_part_size);
+        # derived class can overload this if a different config is desired (e.g. multipart for very large files - those fall back to
+        # awsimple's custom metadata for change detection since their native checksum is composite)
+        s3_transfer_config = TransferConfig(use_threads=False, multipart_threshold=max_single_part_size)
         return s3_transfer_config
 
     @typechecked()
@@ -172,7 +208,8 @@ class S3Access(CacheAccess):
         """
         log.debug(f"writing {self.bucket_name}/{s3_key}")
         assert self.resource is not None
-        self.resource.Object(self.bucket_name, s3_key).put(Body=input_str, Metadata={sha512_string: get_string_sha512(input_str)})
+        # S3 validates the data against the (SDK computed) checksum before storing
+        self.resource.Object(self.bucket_name, s3_key).put(Body=input_str, ChecksumAlgorithm="SHA512")
 
     @typechecked()
     def write_lines(self, input_lines: List[str], s3_key: str):
@@ -220,11 +257,17 @@ class S3Access(CacheAccess):
                 s3_object_metadata = self.get_s3_object_metadata(s3_key)
                 log.info(f"{s3_object_metadata=}")
                 if s3_object_metadata.sha512 is not None:
-                    # use the hash provided by awsimple, if it exists (note that .get_sha512() never returns None - it synthesizes a substitute hash - so check .sha512 itself)
+                    # use the native full-object checksum, if the object has one (note that .get_sha512() never returns None - it synthesizes a substitute hash - so check .sha512 itself)
                     upload_flag = file_sha512 != s3_object_metadata.sha512
+                elif s3_object_metadata.legacy_sha512 is not None:
+                    # the object was written by an older awsimple using the legacy metadata hash - always re-upload it so it gains the native checksum
+                    upload_flag = True
                 else:
-                    # if not, use mtime
-                    upload_flag = not isclose(file_mtime, s3_object_metadata.mtime.timestamp(), abs_tol=self.mtime_abs_tol)
+                    # no hash is available (e.g. the object was written by another tool, or by a multipart upload whose native checksum is composite),
+                    # so compare modification time and file size
+                    sizes_equal = os.path.getsize(file_path) == s3_object_metadata.size
+                    mtimes_equal = isclose(file_mtime, s3_object_metadata.mtime.timestamp(), abs_tol=self.mtime_abs_tol)
+                    upload_flag = not (sizes_equal and mtimes_equal)
             else:
                 upload_flag = True
 
@@ -233,11 +276,9 @@ class S3Access(CacheAccess):
             log.info(f"local file : {file_sha512=},force={force} - uploading")
 
             transfer_retry_count = 0
+            extra_args = self._upload_extra_args()
+            log.info(f"{extra_args=}")
             while not uploaded_flag and transfer_retry_count < self.retry_count:
-                extra_args = {"Metadata": {sha512_string: file_sha512}}
-                if self.public_readable:
-                    extra_args["ACL"] = "public-read"  # type: ignore
-                log.info(f"{extra_args=}")
 
                 try:
                     self.client.upload_file(str(file_path), self.bucket_name, s3_key, ExtraArgs=extra_args, Config=self.get_s3_transfer_config())
@@ -278,8 +319,9 @@ class S3Access(CacheAccess):
             s3_object_metadata = self.get_s3_object_metadata(s3_key)
             log.info(f"{s3_object_metadata=}")
             if s3_object_metadata.sha512 is not None:
-                # use the hash provided by awsimple, if it exists (note that .get_sha512() never returns None - it synthesizes a substitute hash - so check .sha512 itself)
+                # use the native full-object checksum, if the object has one (note that .get_sha512() never returns None - it synthesizes a substitute hash - so check .sha512 itself)
                 upload_flag = json_sha512 != s3_object_metadata.sha512
+            # otherwise upload_flag stays True - objects written by older awsimple (legacy metadata hash) or without any hash are always re-uploaded so they gain the native checksum
 
         uploaded_flag = False
         if upload_flag:
@@ -287,15 +329,14 @@ class S3Access(CacheAccess):
 
             transfer_retry_count = 0
             while not uploaded_flag and transfer_retry_count < self.retry_count:
-                meta_data = {sha512_string: json_sha512}
-                log.info(f"{meta_data=}")
                 assert self.resource is not None
                 try:
                     s3_object = self.resource.Object(self.bucket_name, s3_key)
+                    # S3 validates the data against the (SDK computed) checksum before storing
+                    put_kwargs: Dict[str, Any] = {"Body": json_as_bytes, "ChecksumAlgorithm": "SHA512"}
                     if self.public_readable:
-                        s3_object.put(Body=json_as_bytes, Metadata=meta_data, ACL="public-read")
-                    else:
-                        s3_object.put(Body=json_as_bytes, Metadata=meta_data)
+                        put_kwargs["ACL"] = "public-read"
+                    s3_object.put(**put_kwargs)
                     uploaded_flag = True
                 except connection_errors as e:
                     log.warning(f"{self.bucket_name}:{s3_key} : {transfer_retry_count=} : {e}")
@@ -468,20 +509,23 @@ class S3Access(CacheAccess):
         :return: S3ObjectMetadata
         """
         try:
-            head = self.client.head_object(Bucket=self.bucket_name, Key=s3_key)
+            head = self.client.head_object(Bucket=self.bucket_name, Key=s3_key, ChecksumMode="ENABLED")
         except ClientError as e:
             if boto_error_to_string(e) in ("404", "NoSuchKey", "NotFound"):
                 raise AWSimpleException(f"{self.bucket_name=} {s3_key=} does not exist") from e
             raise
         assert isinstance(self.bucket_name, str)  # mainly for mypy
+        # sha512 is S3's native (server-validated) full-object SHA-512 checksum; legacy_sha512 is awsimple's legacy custom metadata,
+        # kept readable so objects written by older awsimple versions can be detected (and re-uploaded to gain the native checksum)
         s3_object_metadata = S3ObjectMetadata(
             self.bucket_name,
             s3_key,
             head["ContentLength"],
             head["LastModified"],
             head["ETag"][1:-1].lower(),
-            head.get("Metadata", {}).get(sha512_string),
+            _native_checksum_to_hex(head.get("ChecksumSHA512")),
             self.get_s3_object_url(s3_key),
+            head.get("Metadata", {}).get(sha512_string),
         )
         log.debug(f"{s3_object_metadata=}")
         return s3_object_metadata

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 #
 # awsimple requirements
-hashy
+hashy>=0.14.0
 boto3[crt]>=1.43.0
 typeguard
 dictim

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 #
 # awsimple requirements
 hashy
-boto3>=1.43.0
+boto3[crt]>=1.43.0
 typeguard
 dictim
 appdirs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 #
 # awsimple requirements
 hashy
-boto3
+boto3>=1.43.0
 typeguard
 dictim
 appdirs

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     keywords=["aws", "cloud", "storage", "database", "dynamodb", "s3"],
     packages=[__title__],
     package_data={__title__: [readme_file_path, "py.typed"]},
-    install_requires=["boto3", "typeguard", "hashy>=0.1.1", "dictim", "appdirs", "tobool", "urllib3", "python-dateutil", "yasf", "strif"],
+    install_requires=["boto3>=1.43.0", "typeguard", "hashy>=0.1.1", "dictim", "appdirs", "tobool", "urllib3", "python-dateutil", "yasf", "strif"],  # boto3>=1.43.0 for S3 SHA-512 checksum support
     project_urls={"Documentation": "https://awsimple.readthedocs.io/"},
     classifiers=[],
     python_requires=">3.10",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     keywords=["aws", "cloud", "storage", "database", "dynamodb", "s3"],
     packages=[__title__],
     package_data={__title__: [readme_file_path, "py.typed"]},
-    install_requires=["boto3[crt]>=1.43.0", "typeguard", "hashy>=0.1.1", "dictim", "appdirs", "tobool", "urllib3", "python-dateutil", "yasf", "strif"],  # boto3[crt]>=1.43.0 for CRC64NVME checksum support (crt provides awscrt)
+    install_requires=["boto3[crt]>=1.43.0", "typeguard", "hashy>=0.14.0", "dictim", "appdirs", "tobool", "urllib3", "python-dateutil", "yasf", "strif"],  # boto3[crt]>=1.43.0 and hashy>=0.14.0 for CRC64NVME checksum support
     project_urls={"Documentation": "https://awsimple.readthedocs.io/"},
     classifiers=[],
     python_requires=">3.10",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     keywords=["aws", "cloud", "storage", "database", "dynamodb", "s3"],
     packages=[__title__],
     package_data={__title__: [readme_file_path, "py.typed"]},
-    install_requires=["boto3>=1.43.0", "typeguard", "hashy>=0.1.1", "dictim", "appdirs", "tobool", "urllib3", "python-dateutil", "yasf", "strif"],  # boto3>=1.43.0 for S3 SHA-512 checksum support
+    install_requires=["boto3[crt]>=1.43.0", "typeguard", "hashy>=0.1.1", "dictim", "appdirs", "tobool", "urllib3", "python-dateutil", "yasf", "strif"],  # boto3[crt]>=1.43.0 for CRC64NVME checksum support (crt provides awscrt)
     project_urls={"Documentation": "https://awsimple.readthedocs.io/"},
     classifiers=[],
     python_requires=">3.10",

--- a/test_awsimple/test_s3_dir.py
+++ b/test_awsimple/test_s3_dir.py
@@ -1,7 +1,7 @@
 from pprint import pprint
 from pathlib import Path
 
-from awsimple import S3Access
+from awsimple import S3Access, get_bytes_crc64nvme
 
 from test_awsimple import test_awsimple_str, temp_dir
 
@@ -20,7 +20,7 @@ def test_s3_dir():
     pprint(s3_dir)
     md = s3_dir[test_file_name]
     assert md.key == test_file_name
-    assert md.sha512 == "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f"  # "hello world"
+    assert md.crc64nvme == get_bytes_crc64nvme(b"hello world")
 
 
 def test_s3_dir_prefix():
@@ -37,4 +37,4 @@ def test_s3_dir_prefix():
     pprint(s3_dir)
     md = s3_dir[test_file_name]
     assert md.key == test_file_name
-    assert md.sha512 == "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f"  # "hello world"
+    assert md.crc64nvme == get_bytes_crc64nvme(b"hello world")

--- a/test_awsimple/test_s3_dir.py
+++ b/test_awsimple/test_s3_dir.py
@@ -1,7 +1,9 @@
 from pprint import pprint
 from pathlib import Path
 
-from awsimple import S3Access, get_bytes_crc64nvme
+from hashy import get_bytes_crc64nvme
+
+from awsimple import S3Access
 
 from test_awsimple import test_awsimple_str, temp_dir
 

--- a/test_awsimple/test_s3_file_transfer.py
+++ b/test_awsimple/test_s3_file_transfer.py
@@ -6,7 +6,9 @@ import os
 from shutil import rmtree
 from logging import getLogger
 
-from awsimple import S3Access, get_directory_size, is_mock, is_using_localstack, get_bytes_crc64nvme
+from hashy import get_bytes_crc64nvme
+
+from awsimple import S3Access, get_directory_size, is_mock, is_using_localstack
 from test_awsimple import test_awsimple_str, never_change_file_name, temp_dir, cache_dir
 
 big_file_name = "big.txt"

--- a/test_awsimple/test_s3_file_transfer.py
+++ b/test_awsimple/test_s3_file_transfer.py
@@ -6,7 +6,7 @@ import os
 from shutil import rmtree
 from logging import getLogger
 
-from awsimple import S3Access, get_directory_size, is_mock, is_using_localstack
+from awsimple import S3Access, get_directory_size, is_mock, is_using_localstack, get_bytes_crc64nvme
 from test_awsimple import test_awsimple_str, never_change_file_name, temp_dir, cache_dir
 
 big_file_name = "big.txt"
@@ -95,7 +95,7 @@ def test_s3_z_metadata(s3_access):
     test_file_name = "test.txt"
     s3_object_metadata = s3_access.get_s3_object_metadata(test_file_name)
     # "hello world" uploaded with awsimple
-    assert s3_object_metadata.sha512 == "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f"
+    assert s3_object_metadata.crc64nvme == get_bytes_crc64nvme(b"hello world")
     assert s3_object_metadata.size == 11
 
 

--- a/test_awsimple/test_s3_native_checksum.py
+++ b/test_awsimple/test_s3_native_checksum.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 from pathlib import Path
 
-from awsimple import get_bytes_crc64nvme, get_file_crc64nvme
+from hashy import get_bytes_crc64nvme, get_file_crc64nvme
 
 from test_awsimple import temp_dir
 

--- a/test_awsimple/test_s3_native_checksum.py
+++ b/test_awsimple/test_s3_native_checksum.py
@@ -2,34 +2,45 @@ import hashlib
 import os
 from pathlib import Path
 
+from awsimple import get_bytes_crc64nvme, get_file_crc64nvme
+
 from test_awsimple import temp_dir
 
 
 def test_s3_native_checksum_write_string(s3_access):
-    # objects written by awsimple get S3's native SHA-512 checksum, which reads back as the whole-object hex hash
+    # objects written by awsimple get S3's native full-object CRC64NVME checksum, which reads back as the whole-object hex value
     content = "native checksum test"
     s3_key = "native_checksum_test.txt"
     s3_access.write_string(content, s3_key)
     metadata = s3_access.get_s3_object_metadata(s3_key)
-    assert metadata.sha512 == hashlib.sha512(content.encode()).hexdigest()
+    assert metadata.crc64nvme == get_bytes_crc64nvme(content.encode())
+    assert metadata.get_sha512() == metadata.crc64nvme  # the checksum is also the cache key
 
 
-def test_s3_native_checksum_without_custom_metadata(s3_access):
-    # an object written by some other tool with a native checksum (but no awsimple custom metadata) still gets a usable sha512
+def test_s3_foreign_object_with_native_sha512(s3_access):
+    # an object written by some other tool with a native SHA-512 checksum is still recognized and comparable
     content = b"written by some other tool"
-    s3_key = "native_checksum_no_metadata.txt"
+    s3_key = "native_checksum_sha512.txt"
     s3_access.client.put_object(Bucket=s3_access.bucket_name, Key=s3_key, Body=content, ChecksumAlgorithm="SHA512")
     metadata = s3_access.get_s3_object_metadata(s3_key)
     assert metadata.sha512 == hashlib.sha512(content).hexdigest()
+    assert metadata.crc64nvme is None
+
+    # uploading identical content compares via the object's SHA-512 and is skipped
+    file_path = Path(temp_dir, "native_checksum_sha512.txt")
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(content)
+    assert not s3_access.upload(file_path, s3_key)
 
 
-def test_s3_no_checksum_no_metadata(s3_access):
-    # neither a native SHA-512 checksum nor custom metadata - .sha512 is None and get_sha512() provides the substitute hash
-    content = b"no checksum at all"
-    s3_key = "no_checksum_at_all.txt"
+def test_s3_no_full_object_hash(s3_access):
+    # no full-object hash awsimple understands (raw put gets the SDK default CRC32) - .sha512/.crc64nvme are None and get_sha512() provides the substitute hash
+    content = b"no full-object hash"
+    s3_key = "no_full_object_hash.txt"
     s3_access.client.put_object(Bucket=s3_access.bucket_name, Key=s3_key, Body=content)
     metadata = s3_access.get_s3_object_metadata(s3_key)
     assert metadata.sha512 is None
+    assert metadata.crc64nvme is None
     assert metadata.legacy_sha512 is None
     assert metadata.get_sha512() is not None  # substitute hash so caching still works
 
@@ -43,25 +54,26 @@ def test_s3_legacy_metadata_object_always_reuploaded(s3_access):
 
     metadata = s3_access.get_s3_object_metadata(s3_key)
     assert metadata.sha512 is None  # no native checksum
+    assert metadata.crc64nvme is None
     assert metadata.legacy_sha512 == content_sha512  # legacy metadata hash detected
 
-    # upload the identical content - it would be skipped if the native checksum existed, but legacy objects always migrate
+    # upload the identical content - it would be skipped if a native checksum existed, but legacy objects always migrate
     file_path = Path(temp_dir, "legacy_metadata_object.txt")
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_bytes(content)
     assert s3_access.upload(file_path, s3_key)  # re-uploaded (migrated), even though the content is unchanged
 
     metadata = s3_access.get_s3_object_metadata(s3_key)
-    assert metadata.sha512 == content_sha512  # now has the native checksum
+    assert metadata.crc64nvme == get_bytes_crc64nvme(content)  # now has the native checksum
     assert metadata.legacy_sha512 is None  # legacy metadata is gone
     assert not s3_access.upload(file_path, s3_key)  # migration complete - unchanged content is now skipped
 
 
 def test_s3_no_hash_mtime_and_size_comparison(s3_access):
-    # when the object has no hash of any kind, change detection falls back to modification time and file size
+    # when the object has no full-object hash, change detection falls back to modification time and file size
     content = b"0123456789"
     s3_key = "no_hash_mtime_size.txt"
-    s3_access.client.put_object(Bucket=s3_access.bucket_name, Key=s3_key, Body=content)  # no hash of any kind
+    s3_access.client.put_object(Bucket=s3_access.bucket_name, Key=s3_key, Body=content)  # no full-object hash
     mtime_ts = s3_access.get_s3_object_metadata(s3_key).mtime.timestamp()
 
     file_path = Path(temp_dir, "no_hash_mtime_size.txt")
@@ -83,7 +95,20 @@ def test_s3_native_checksum_upload_skip(s3_access):
     s3_key = "native_checksum_upload.txt"
     assert s3_access.upload(file_path, s3_key, force=True)
     metadata = s3_access.get_s3_object_metadata(s3_key)
-    assert metadata.sha512 == hashlib.sha512(b"upload me").hexdigest()
+    assert metadata.crc64nvme == get_bytes_crc64nvme(b"upload me")
     assert not s3_access.upload(file_path, s3_key)  # unchanged, so no upload happens
     file_path.write_text("upload me again")
     assert s3_access.upload(file_path, s3_key)  # changed, so it uploads
+
+
+def test_s3_multipart_full_object_checksum(s3_access):
+    # multipart uploads (above the 8 MiB threshold) still get a full-object CRC64NVME checksum, so change detection works at any size
+    file_path = Path(temp_dir, "multipart_checksum.bin")
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(os.urandom(20 * 1024 * 1024))  # 20 MB - uploads as multiple parts
+    s3_key = "multipart_checksum.bin"
+
+    assert s3_access.upload(file_path, s3_key, force=True)
+    metadata = s3_access.get_s3_object_metadata(s3_key)
+    assert metadata.crc64nvme == get_file_crc64nvme(file_path)  # full-object checksum, not a composite
+    assert not s3_access.upload(file_path, s3_key)  # unchanged, so no upload happens

--- a/test_awsimple/test_s3_native_checksum.py
+++ b/test_awsimple/test_s3_native_checksum.py
@@ -1,0 +1,89 @@
+import hashlib
+import os
+from pathlib import Path
+
+from test_awsimple import temp_dir
+
+
+def test_s3_native_checksum_write_string(s3_access):
+    # objects written by awsimple get S3's native SHA-512 checksum, which reads back as the whole-object hex hash
+    content = "native checksum test"
+    s3_key = "native_checksum_test.txt"
+    s3_access.write_string(content, s3_key)
+    metadata = s3_access.get_s3_object_metadata(s3_key)
+    assert metadata.sha512 == hashlib.sha512(content.encode()).hexdigest()
+
+
+def test_s3_native_checksum_without_custom_metadata(s3_access):
+    # an object written by some other tool with a native checksum (but no awsimple custom metadata) still gets a usable sha512
+    content = b"written by some other tool"
+    s3_key = "native_checksum_no_metadata.txt"
+    s3_access.client.put_object(Bucket=s3_access.bucket_name, Key=s3_key, Body=content, ChecksumAlgorithm="SHA512")
+    metadata = s3_access.get_s3_object_metadata(s3_key)
+    assert metadata.sha512 == hashlib.sha512(content).hexdigest()
+
+
+def test_s3_no_checksum_no_metadata(s3_access):
+    # neither a native SHA-512 checksum nor custom metadata - .sha512 is None and get_sha512() provides the substitute hash
+    content = b"no checksum at all"
+    s3_key = "no_checksum_at_all.txt"
+    s3_access.client.put_object(Bucket=s3_access.bucket_name, Key=s3_key, Body=content)
+    metadata = s3_access.get_s3_object_metadata(s3_key)
+    assert metadata.sha512 is None
+    assert metadata.legacy_sha512 is None
+    assert metadata.get_sha512() is not None  # substitute hash so caching still works
+
+
+def test_s3_legacy_metadata_object_always_reuploaded(s3_access):
+    # an object written by an older awsimple (legacy metadata hash, no native checksum) is always re-uploaded so it gains the native checksum
+    content = b"legacy object"
+    content_sha512 = hashlib.sha512(content).hexdigest()
+    s3_key = "legacy_metadata_object.txt"
+    s3_access.client.put_object(Bucket=s3_access.bucket_name, Key=s3_key, Body=content, Metadata={"awsimple-sha512": content_sha512})
+
+    metadata = s3_access.get_s3_object_metadata(s3_key)
+    assert metadata.sha512 is None  # no native checksum
+    assert metadata.legacy_sha512 == content_sha512  # legacy metadata hash detected
+
+    # upload the identical content - it would be skipped if the native checksum existed, but legacy objects always migrate
+    file_path = Path(temp_dir, "legacy_metadata_object.txt")
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(content)
+    assert s3_access.upload(file_path, s3_key)  # re-uploaded (migrated), even though the content is unchanged
+
+    metadata = s3_access.get_s3_object_metadata(s3_key)
+    assert metadata.sha512 == content_sha512  # now has the native checksum
+    assert metadata.legacy_sha512 is None  # legacy metadata is gone
+    assert not s3_access.upload(file_path, s3_key)  # migration complete - unchanged content is now skipped
+
+
+def test_s3_no_hash_mtime_and_size_comparison(s3_access):
+    # when the object has no hash of any kind, change detection falls back to modification time and file size
+    content = b"0123456789"
+    s3_key = "no_hash_mtime_size.txt"
+    s3_access.client.put_object(Bucket=s3_access.bucket_name, Key=s3_key, Body=content)  # no hash of any kind
+    mtime_ts = s3_access.get_s3_object_metadata(s3_key).mtime.timestamp()
+
+    file_path = Path(temp_dir, "no_hash_mtime_size.txt")
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(content)
+    os.utime(file_path, (mtime_ts, mtime_ts))
+    assert not s3_access.upload(file_path, s3_key)  # same mtime and same size - no upload
+
+    file_path.write_bytes(content + b"more")
+    os.utime(file_path, (mtime_ts, mtime_ts))
+    assert s3_access.upload(file_path, s3_key)  # same mtime but different size - uploads
+
+
+def test_s3_native_checksum_upload_skip(s3_access):
+    # change detection via the native checksum: an unchanged file is not re-uploaded
+    file_path = Path(temp_dir, "native_checksum_upload.txt")
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("upload me")
+    s3_key = "native_checksum_upload.txt"
+    assert s3_access.upload(file_path, s3_key, force=True)
+    metadata = s3_access.get_s3_object_metadata(s3_key)
+    assert metadata.sha512 == hashlib.sha512(b"upload me").hexdigest()
+    assert not s3_access.upload(file_path, s3_key)  # unchanged, so no upload happens
+    file_path.write_text("upload me again")
+    assert s3_access.upload(file_path, s3_key)  # changed, so it uploads

--- a/test_awsimple/test_s3_string.py
+++ b/test_awsimple/test_s3_string.py
@@ -1,4 +1,4 @@
-from awsimple import S3Access
+from awsimple import S3Access, get_bytes_crc64nvme
 
 from test_awsimple import test_awsimple_str
 
@@ -10,5 +10,4 @@ def test_s3_string():
     metadata = d[test_awsimple_str]
     assert metadata.size == len(test_awsimple_str)
     assert metadata.key == test_awsimple_str  # the contents are the same as the key
-    # https://passwordsgenerator.net/sha512-hash-generator/
-    assert metadata.sha512.lower() == "D16764F12E4D13555A88372CFE702EF8AE07F24A3FFCEDE6E1CDC8B7BFC2B18EC3468A7752A09F100C9F24EA2BC77566A08972019FC04CF75AB3A64B475BDFA3".lower()
+    assert metadata.crc64nvme == get_bytes_crc64nvme(test_awsimple_str.encode())

--- a/test_awsimple/test_s3_string.py
+++ b/test_awsimple/test_s3_string.py
@@ -1,4 +1,6 @@
-from awsimple import S3Access, get_bytes_crc64nvme
+from hashy import get_bytes_crc64nvme
+
+from awsimple import S3Access
 
 from test_awsimple import test_awsimple_str
 


### PR DESCRIPTION
## Summary

Replaces awsimple's custom `awsimple-sha512` S3 object metadata with S3's native checksums (April 2026 S3 checksum expansion), landing on CRC64NVME as the single algorithm for all writes.

### Why CRC64NVME
- It's the only checksum family S3 computes as a **full-object** value for both single-part and multipart uploads, so change detection behaves identically at any file size.
- It's S3's own default when no checksum is provided, so objects written by other modern tools usually carry a comparable checksum.
- S3 **validates the data server-side** against the SDK-computed checksum before storing - the legacy custom metadata was a label nothing ever verified.
- Not cryptographic, but random-collision odds (~2^-64) are more than adequate for change detection and cache keying (awsimple's uses). The README no longer claims "true file hashing".

### Behavior
Upload change detection tiers:
1. Native full-object CRC64NVME → compare with locally computed value (via hashy)
2. Native full-object SHA-512 (objects written by other tools) → compare with local SHA-512
3. Legacy awsimple metadata hash → **always re-upload**, migrating the object to the native checksum
4. No hash at all → modification-time and file-size comparison

- The legacy metadata is no longer written; it is only read (`S3ObjectMetadata.legacy_sha512`) to detect old objects for migration.
- `S3ObjectMetadata` gains `crc64nvme` and `legacy_sha512` fields; `get_sha512()` (cache key) prefers native checksums and falls back to the substitute hash.
- Multipart threshold is boto3's common 8 MiB default (an interim 5 GiB single-PUT design was rejected for transfer-reliability risk).
- Local CRC64NVME computation uses hashy 0.14.0's new `get_bytes_crc64nvme`/`get_file_crc64nvme` (verified byte-identical to awscrt and to S3's returned values, including a 3-part multipart upload).

### Dependencies
- `boto3[crt]>=1.43.0` - verified 1.43.0 is the exact botocore floor with the new checksum enums; the `crt` extra provides awscrt, which botocore requires to compute CRC64NVME during uploads.
- `hashy>=0.14.0` - CRC64NVME support.

### Versioning
Major bump to **8.0.0**: checksum wire-format change, one-time re-upload migration of legacy objects, and new dependency floors.

### Tests
7 new tests in `test_s3_native_checksum.py` covering the native checksum on writes, foreign SHA-512 objects, no-hash objects (substitute hash), legacy-object migration, mtime+size fallback, upload skip, and multipart full-object checksums (20 MB, 3 parts). Existing SHA-512 assertions updated to CRC64NVME. Full suite: 98 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)